### PR TITLE
Release 1.3.2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,8 @@
     ],
 
     "editor.formatOnPaste": false,
-    "auto-close-tag.enableAutoCloseTag": false
+    "auto-close-tag.enableAutoCloseTag": false,
+
+    "smartOpen.pinnedDocument.pinnedDocuments": [],
+
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 
-## [1.3.0] - 2019-02-07
+## [1.3.2] - 2019-07-08
+
+### Changed
+
+* Extension now format regex for settings `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles`
+  * Now you can use `*`, `.`, `\` as normal
+  * Updated `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles` default values
+  * !!! You need update your regex as well.
+
+### Bug fixes
+
+* Could not remove pinned document if no editor opened
+
+## [1.3.0] - 2019-07-02
 
 ### Added
 
@@ -49,6 +62,3 @@
 * Add support for variables {number}, {-number},
 * Built in tag for Angular, Default, C#, C++
 * Allow custom tag to be created and used
-
-[Unreleased]: https://github.com/smartytomato/smartopen/changelog/unreleased.md
-[1.0.0]: https://github.com/smartytomato/smartopen/changelog/1.0.0.md

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Send me through your configs I will make them built in.
 
 ### Pin documents
 
-<img src="https://raw.githubusercontent.com/SmartyTomato/SmartOpen/master/resources/img/readme/readme_2.jpg" alt="Pinned documents">
+<img src="https://raw.githubusercontent.com/SmartyTomato/SmartOpen/master/resources/img/readme/readme_2.jpg" alt="Pinned documents"/>
 
 Pin documents to the top of the explorer panel using shortcut and then quick pick pinned documents with shortcut to boost your productivity.
 
@@ -38,7 +38,8 @@ Note:
 <img src="https://raw.githubusercontent.com/SmartyTomato/SmartOpen/master/resources/img/readme/readme_1.png" alt="">
 
 Shortcuts:
-Open related files using `Ctrl + ;`
+
+Open related files: `Ctrl + ;`
 
 E.g.
 
@@ -64,7 +65,7 @@ E.g.
 
 * `smartOpen.pinnedDocument.maintainSortOrder`:
   * Description: Should maintain sort order for pinned documents in the view when new document pinned
-  * Default: true
+  * Default: false
   * Options: true or false
 
 * `smartOpen.pinnedDocument.pinnedDocuments`:
@@ -139,14 +140,17 @@ Due to the single thread limitation, the performance for this extension depends 
 
 ## Release Notes
 
-## [1.3.0] - 2019-02-07
+### Changed
 
-### Added
+* Extension now format regex for settings `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles`
+  * Now you can use `*`, `.`, `\` as normal
+  * Updated `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles` default values
+  * !!! You need update your regex as well.
 
-* New feature! - Pin documents
-  * Pinned documents panel
-  * Editor right click context menu
+### Bug fixes
 
-<img src="https://raw.githubusercontent.com/SmartyTomato/SmartOpen/master/resources/img/readme/readme_2.jpg" alt="Pinned documents">
+* Could not remove pinned document if no editor opened
 
-[CHANGELOG]: https://github.com/smartytomato/smartopen/CHANGELOG.md
+## Change Log
+
+[CHANGELOG](https://github.com/smartytomato/smartopen/CHANGELOG.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "smartopen",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "smartopen",
 	"displayName": "%displayName%",
 	"description": "%description%",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"engines": {
 		"vscode": "^1.32.0"
 	},

--- a/package.json
+++ b/package.json
@@ -87,20 +87,20 @@
 			{
 				"command": "smartOpen.pinnedDocument.editor.pin",
 				"key": "ctrl+'",
-				"when": "editorTextFocus"
+				"when": "editorTextFocus && config.smartOpen.pinnedDocument.enabled"
 			},
 			{
 				"command": "smartOpen.pinnedDocument.editor.unpin",
 				"key": "ctrl+shift+'",
-				"when": "editorTextFocus"
+				"when": "editorTextFocus && config.smartOpen.pinnedDocument.enabled"
 			},
 			{
 				"command": "smartOpen.pinnedDocument.quickPick",
-				"key": "ctrl+alt+'"
+				"key": "ctrl+alt+' && config.smartOpen.pinnedDocument.enabled"
 			},
 			{
 				"command": "smartOpen.pinnedDocument.view.openAll",
-				"key": "ctrl+shift+alt+'"
+				"key": "ctrl+shift+alt+' && config.smartOpen.pinnedDocument.enabled"
 			}
 		],
 		"views": {
@@ -116,11 +116,13 @@
 			"editor/title/context": [
 				{
 					"command": "smartOpen.pinnedDocument.editor.pin",
-					"group": "navigation@0"
+					"group": "navigation@0",
+					"when": "config.smartOpen.pinnedDocument.enabled"
 				},
 				{
 					"command": "smartOpen.pinnedDocument.editor.unpin",
-					"group": "navigation@1"
+					"group": "navigation@1",
+					"when": "config.smartOpen.pinnedDocument.enabled"
 				}
 			],
 			"view/item/context": [
@@ -208,18 +210,18 @@
 						},
 						"uniqueItems": true,
 						"default": [
-							".*",
-							".*.ts",
-							".*.cs",
-							".*.xml",
-							".*.h",
-							".*.cpp",
-							".*.json",
-							".*.html",
-							".*.css",
-							".*.less",
-							".*.sass",
-							".*.js"
+							"*",
+							"*.ts",
+							"*.cs",
+							"*.xml",
+							"*.h",
+							"*.cpp",
+							"*.json",
+							"*.html",
+							"*.css",
+							"*.less",
+							"*.sass",
+							"*.js"
 						],
 						"description": "(Remove) first item to Enable. Only include file name, full path and relative path with the given regexp, add this to significant reduce the calculation time"
 					},
@@ -233,7 +235,7 @@
 						},
 						"uniqueItems": true,
 						"default": [
-							"\\..*",
+							"\\.*",
 							"__.*",
 							"node_modules",
 							"[Dd]ebug",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,6 @@
 {
-    "displayName":"Smart Open",
-    "description": "SmartOpen is an extension opens related files in the project",
+    "displayName":"SmartOpen",
+    "description": "SmartOpen is a vscode extension help user better manage opened documents",
     "contributes.views.explorer.pinnedDocument": "Pinned Documents",
 
     "contributes.commands.smartOpen.openRelatedFile.quickPick":"Open Related File",

--- a/src/openRelatedFile/openRelatedFileService.ts
+++ b/src/openRelatedFile/openRelatedFileService.ts
@@ -42,8 +42,10 @@ class OpenRelatedFileService {
         console.debug(`Active file >>> ${JSON.stringify(activeFile)}`);
 
         // Get configs for file filters
-        let config = configService.get();
-        let fileInfos = this.getAllFilesInCurrentWorkspace(config.fileFilters, config.ignoredFiles);
+        let fileInfos = this.getAllFilesInCurrentWorkspace(
+            configService.getFileFilters(),
+            configService.getIgnoredFiles(),
+        );
 
         // * Calculate related files
         let matchResults = this.getRelatedFiles(activeFile, fileInfos);

--- a/src/pinnedDocument/pinnedDocumentService.ts
+++ b/src/pinnedDocument/pinnedDocumentService.ts
@@ -67,7 +67,7 @@ class PinnedDocumentService {
      */
     unpinDocument(uri: Uri) {
         let activeTextEditor = vscode.window.activeTextEditor;
-        if (!activeTextEditor) {
+        if (!uri && !activeTextEditor) {
             vscode.window.showInformationMessage(`Unpin current document activated, but no active text editor`);
             console.log(`Unpin current document activated, but no active text editor`);
             return;

--- a/src/utils/configService.ts
+++ b/src/utils/configService.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { Uri } from "vscode";
 
+import { utility } from "./utility";
 import { Rule } from "../openRelatedFile/model/rule";
 import { Config } from "./model/config";
 
@@ -49,6 +50,28 @@ class ConfigService {
         } else {
             return config.rules.filter(x => x.tags.some(p => config.activatedTags.includes(p)));
         }
+    }
+
+    getFileFilters(): Array<string> {
+        let config = this.get();
+
+        let filters = [];
+        for (let item of config.fileFilters) {
+            filters.push(utility.formatRegex(item));
+        }
+
+        return filters;
+    }
+
+    getIgnoredFiles(): Array<string> {
+        let config = this.get();
+
+        let ignoredFiles = [];
+        for (let item of config.ignoredFiles) {
+            ignoredFiles.push(utility.formatRegex(item));
+        }
+
+        return ignoredFiles;
     }
 
     updateSortBy(value: string) {

--- a/src/utils/utility.ts
+++ b/src/utils/utility.ts
@@ -1,0 +1,48 @@
+class ReplaceString {
+    search: string;
+    replace: string;
+}
+
+class Utility {
+    regexSpecialChars: Array<ReplaceString> = [
+        { search: "*", replace: ".*" },
+        { search: "\\", replace: "\\\\" },
+        { search: ".", replace: "\\." },
+    ];
+
+    formatRegex(regex: string): string {
+        return this.replaceAllBatch(regex, this.regexSpecialChars);
+    }
+
+    replaceAllBatch(text: string, matches: Array<ReplaceString>): string {
+        let result = text;
+        let end = -1;
+        let match = null;
+
+        for (let item of matches) {
+            let found = text.indexOf(item.search);
+
+            if (found >= 0 && (end === -1 || found < end)) {
+                end = found + 1;
+                match = item;
+            }
+        }
+
+        if (end >= 0) {
+            let selected = text.substring(0, end);
+            selected = selected.replace(match.search, match.replace);
+
+            let remaining = text.substring(end);
+            if (remaining) {
+                result = selected + this.replaceAllBatch(remaining, matches);
+            } else {
+                result = selected;
+            }
+        }
+
+        return result;
+    }
+}
+
+let utility = new Utility();
+export { utility };

--- a/todo.txt
+++ b/todo.txt
@@ -1,3 +1,6 @@
 Bug
 - format regex
 - regex remove the need for . before *
+
+Fixes
+- Remove context menu if pinned document disabled


### PR DESCRIPTION
## [1.3.2] - 2019-07-08

### Changed

* Extension now format regex for settings `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles`
  * Now you can use `*`, `.`, `\` as normal
  * Updated `smartOpen.openRelatedFile.fileFilters` and `smartOpen.openRelatedFile.ignoredFiles` default values
  * !!! You need update your regex as well.

### Bug fixes

* Could not remove pinned document if no editor opened